### PR TITLE
ARROW-17980: [Python] Add find_package(Protobuf) to python/CMakeLists

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -232,6 +232,19 @@ include_directories(SYSTEM ${NUMPY_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS} src)
 # Dependencies
 #
 
+if(ARROW_PROTOBUF_USE_SHARED)
+  find_package(Protobuf)
+  include_directories(${PROTOBUF_INCLUDE_DIRS})
+  get_property(dirs DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
+  foreach(dir ${dirs})
+    message("dir='${dir}'")
+  endforeach()
+  get_cmake_property(_variableNames VARIABLES)
+  foreach (_variableName ${_variableNames})
+    message("${_variableName}=${${_variableName}}")
+  endforeach()
+endif()
+
 if(PYARROW_BUILD_FLIGHT)
   set(ARROW_FLIGHT TRUE)
 endif()


### PR DESCRIPTION
During testing of this internally. We found that python/CMakeLists.txt is missing find_package(Protobuf) so we cannot use internal version of protobuf. This PR should fix that.