### PR TITLE
ARROW-????: (Backpressure PR): Adjust backpressure counter to start at 1.

### DIFF
--- a/cpp/src/arrow/compute/exec/asof_join_node.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node.cc
@@ -1342,7 +1342,7 @@ AsofJoinNode::AsofJoinNode(ExecPlan* plan, NodeVector inputs,
       must_hash_(must_hash),
       may_rehash_(may_rehash),
       tolerance_(tolerance),
-      backpressure_counter_(0),
+      backpressure_counter_(1),
       process_(),
       process_thread_(&AsofJoinNode::ProcessThreadWrapper, this) {
   finished_ = arrow::Future<>::MakeFinished();


### PR DESCRIPTION
The source node starts its counter at 0 and so it will ignore a pause message with counter value 0.  This leads to one side of the join pausing while the other side keeps going.  The side that keeps going ends up accumulating too much in memory.